### PR TITLE
fix: reissue 로직 수정

### DIFF
--- a/src/main/java/com/ddang/member/controller/MemberController.java
+++ b/src/main/java/com/ddang/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.ddang.global.api.ApiResponse;
 import com.ddang.global.exception.annotation.SwaggerExceptionResponse;
 import com.ddang.member.controller.request.IsMatchedRequest;
 import com.ddang.member.controller.request.JoinRequest;
+import com.ddang.member.controller.request.ReissueRequest;
 import com.ddang.member.controller.request.UpdateRequest;
 import com.ddang.member.oauth2.CustomOAuth2User;
 import com.ddang.member.service.MemberService;
@@ -48,10 +49,11 @@ public class MemberController {
             description = "RefreshToken을 사용하여 새로운 AccessToken을 발급합니다. 모든 요청 시 AccessToken의 유효기간이 지나 401을 반환받은 경우 /reissue로 재발급 받아 사용합니다."
     )
     @SwaggerExceptionResponse({UNAUTHORIZED_RTK_ERROR, MEMBER_NOT_FOUND})
-    public ApiResponse<String> reissue(HttpServletRequest request, HttpServletResponse response) {
+    public ApiResponse<String> reissue(@RequestBody @Valid ReissueRequest reissueRequest, HttpServletResponse response) {
         log.info("reissue() 메서드 진입");
 
-        String newAccessToken = memberService.reissueAccessToken(request, response);
+        String email = reissueRequest.email();
+        String newAccessToken = memberService.reissueAccessToken(email, response);
         log.info("새로운 AccessToken 생성: {}", newAccessToken);
 
         // ApiResponse 사용하여 응답 반환

--- a/src/main/java/com/ddang/member/controller/request/ReissueRequest.java
+++ b/src/main/java/com/ddang/member/controller/request/ReissueRequest.java
@@ -1,0 +1,13 @@
+package com.ddang.member.controller.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "AccessToken 재발급 요청 데이터")
+public record ReissueRequest(
+
+    @NotNull(message = "회원 이메일을 입력해주세요.")
+    @Schema(description = "회원 이메일", example = "email")
+    String email
+) {
+}

--- a/src/main/java/com/ddang/member/service/MemberService.java
+++ b/src/main/java/com/ddang/member/service/MemberService.java
@@ -12,7 +12,7 @@ public interface MemberService {
 
     MemberResponse join(JoinServiceRequest serviceRequest, HttpServletResponse response);
 
-    String reissueAccessToken(HttpServletRequest request, HttpServletResponse response);
+    String reissueAccessToken(String email, HttpServletResponse response);
 
     String logout(HttpServletRequest request);
 

--- a/src/main/java/com/ddang/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/ddang/member/service/MemberServiceImpl.java
@@ -59,17 +59,10 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public String reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
-
-        String refreshToken = jwtService.extractRefreshTokenFromCookie(request)
-                .filter(jwtService::isTokenValid)
-                .orElseThrow(() -> new AuthenticationException(ErrorCode.UNAUTHORIZED_RTK_ERROR));
-
-        String email = jwtService.extractEmailFromRefreshToken(refreshToken)
-                .orElseThrow(() -> new AuthenticationException(ErrorCode.UNAUTHORIZED_RTK_ERROR));
+    public String reissueAccessToken(String email, HttpServletResponse response) {
 
         jwtService.getRefreshTokenFromRedis(email)
-                .filter(storedToken -> storedToken.equals(refreshToken))
+                .filter(jwtService::isTokenValid)
                 .orElseThrow(() -> new AuthenticationException(ErrorCode.UNAUTHORIZED_RTK_ERROR));
 
         Member member = memberRepository.findByEmail(email)

--- a/src/test/java/com/ddang/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/ddang/member/controller/MemberControllerTest.java
@@ -2,6 +2,7 @@ package com.ddang.member.controller;
 
 import com.ddang.member.controller.request.IsMatchedRequest;
 import com.ddang.member.controller.request.JoinRequest;
+import com.ddang.member.controller.request.ReissueRequest;
 import com.ddang.member.entity.*;
 import com.ddang.member.oauth2.CustomOAuth2User;
 import com.ddang.member.service.MemberServiceImpl;
@@ -36,6 +37,7 @@ import static com.ddang.member.entity.IsMatched.TRUE;
 import static com.ddang.member.entity.Provider.KAKAO;
 import static com.ddang.member.entity.Role.USER;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -101,14 +103,19 @@ public class MemberControllerTest {
         // given
         String dummyAccessToken = "dummyNewAccessToken";
 
-        when(memberService.reissueAccessToken(any(HttpServletRequest.class), any(HttpServletResponse.class)))
+        when(memberService.reissueAccessToken(anyString(), any(HttpServletResponse.class)))
                 .thenReturn(dummyAccessToken);
+
+        ReissueRequest request = new ReissueRequest("email@example.com");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestJson = objectMapper.writeValueAsString(request);
 
         // when & then
         mockMvc.perform(post("/api/v1/member/reissue")
-                        .with(csrf()) // CSRF 보호를 우회하기 위한 토큰 추가
-                        .cookie(new Cookie("refreshToken", "dummyRefreshToken"))
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").value(dummyAccessToken));
     }

--- a/src/test/java/com/ddang/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/ddang/member/service/MemberServiceImplTest.java
@@ -141,23 +141,21 @@ class MemberServiceImplTest {
     @DisplayName("AccessToken 재발급 테스트")
     void reissueAccessTokenTest() {
         // given
-        when(jwtService.extractRefreshTokenFromCookie(request)).thenReturn(Optional.of(VALID_REFRESH_TOKEN));
-        when(jwtService.isTokenValid(VALID_REFRESH_TOKEN)).thenReturn(true);
-        when(jwtService.extractEmailFromRefreshToken(VALID_REFRESH_TOKEN)).thenReturn(Optional.of(EMAIL));
         when(jwtService.getRefreshTokenFromRedis(EMAIL)).thenReturn(Optional.of(VALID_REFRESH_TOKEN));
+        when(jwtService.isTokenValid(VALID_REFRESH_TOKEN)).thenReturn(true);
         when(memberRepository.findByEmail(EMAIL)).thenReturn(Optional.of(member));
-        when(jwtService.createAccessToken(any(), any())).thenReturn(NEW_ACCESS_TOKEN);
-        when(jwtService.createRefreshToken(any())).thenReturn(NEW_REFRESH_TOKEN);
+        when(jwtService.createAccessToken(member.getEmail(), member.getProvider().name())).thenReturn(NEW_ACCESS_TOKEN);
+        when(jwtService.createRefreshToken(member.getEmail())).thenReturn(NEW_REFRESH_TOKEN);
 
         // when
-        String resultToken = memberService.reissueAccessToken(request, response);
+        String resultToken = memberService.reissueAccessToken(EMAIL, response);
 
         // then
         assertThat(resultToken).isEqualTo(NEW_ACCESS_TOKEN);
 
         // verify
         verify(jwtService, times(1)).removeRefreshTokenFromRedis(EMAIL);
-        verify(jwtService, times(1)).saveRefreshTokenToRedis(EMAIL, NEW_REFRESH_TOKEN);
+        verify(jwtService, times(1)).saveRefreshTokenToRedis(member.getEmail(), NEW_REFRESH_TOKEN);
         verify(jwtService, times(1)).sendAccessAndRefreshToken(response, NEW_ACCESS_TOKEN, NEW_REFRESH_TOKEN);
     }
 


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
AccessToken 만료 시 재발급을 받을 수 있는 reissue() 메서드를 수정했습니다.

기존 웹에서는 HttpServletRequest를 사용해서 쿠키에 저장되어있는 RefreshToken을 가져와 유효성 검증 후 토큰을 재발급 해주었지만, 이 방식은 앱에서는 불가능하다는 프론트의 피드백을 받아 email을 통해 rtk를 조회하고 유효성 검증 후 재발급을 해주는 로직으로 수정하였습니다.

## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #57
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->
프론트에서 테스트를 하기 위해 바로 merge 하겠습니다.